### PR TITLE
Update the information about dictionaries order

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ with open("myfile.txt") as f:
 
 Dictionaries
 ----------
-**Also known as mappings or hash tables. They are key value pairs that DO NOT retain order**
+**Also known as mappings or hash tables. They are key value pairs that are guaranteed to retain order of insertion starting from Python 3.7**
 ```python
 my_dict = {'name': 'Andrei Neagoie', 'age': 30, 'magic_power': False}
 my_dict['name']                      # Andrei Neagoie


### PR DESCRIPTION
According to the official documentation https://docs.python.org/3.7/library/stdtypes.html#typesmapping:
_Changed in version 3.7:_ Dictionary order is guaranteed to be insertion order. This behavior was an implementation detail of CPython from 3.6.